### PR TITLE
[FEATURE]remove SelectLang in HeaderRight and add the account setting item in AvatarDrowdown

### DIFF
--- a/src/RightContent/AvatarDropdown.tsx
+++ b/src/RightContent/AvatarDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { LogoutOutlined } from '@ant-design/icons';
+import { LogoutOutlined, SettingOutlined } from '@ant-design/icons';
 import { Avatar, Menu, Spin } from 'antd';
 import HeaderDropdown from './HeaderDropdown';
 import { UserOutlined } from '@ant-design/icons';
@@ -32,6 +32,7 @@ const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ onUserlogout, format
       if (key === 'logout' && currentUser) {
         loginOut(onUserlogout);
       }
+      if(key === 'setting') window.location.assign(`${getSsoUrl()}/profile`);
     },
     [currentUser, onUserlogout]
   );
@@ -58,6 +59,12 @@ const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ onUserlogout, format
 
   const menuHeaderDropdown = (
     <Menu className={styles.menu} onClick={onMenuClick}>
+      <Menu.Item key='setting'>
+        <SettingOutlined />
+        {formatMessage({
+          id: 'common.nav.settings'
+        })}
+      </Menu.Item>
       <Menu.Item key='logout'>
         <LogoutOutlined />
         {formatMessage({

--- a/src/RightContent/HeaderRight.tsx
+++ b/src/RightContent/HeaderRight.tsx
@@ -2,7 +2,6 @@ import { Tag, Space } from 'antd';
 import React from 'react';
 import styles from './index.less';
 import Avatar from './AvatarDropdown';
-import SelectLang from './SelectLang';
 import ExplorationDropdown from './ExplorationDropdown';
 import InfoDropdown from './InfoDropdown';
 
@@ -37,7 +36,6 @@ export const HeaderRight: React.FC<HeaderRightProps> = ({
   currentUser,
   onTracking,
   services,
-  onUpdateLocale,
 }) => {
   let className = styles.right;
 
@@ -58,7 +56,6 @@ export const HeaderRight: React.FC<HeaderRightProps> = ({
           <Tag color={ENVTagColor[versionTag]}>{versionTag}</Tag>
         </span>
       )}
-      <SelectLang onUpdateLocale={onUpdateLocale} />
     </Space>
   );
 };


### PR DESCRIPTION
Description:

- remove SelectLang in HeaderRight 
- add the account setting item in AvatarDrowdown
    * redirect user to sso profile page when user click the account setting 


<img width="319" alt="截圖 2022-05-12 下午2 30 42" src="https://user-images.githubusercontent.com/34614986/168006293-51f056b9-2e3f-40da-af41-0020bd958770.png">



CheckList:
- [ ] You have pass unit test. 
- [ ] You have added unit tests.
- [ ] You have edit storybook document. If you add or update component.