### PR TITLE
Add extend dropdown menu props

### DIFF
--- a/src/RightContent/AvatarDropdown.tsx
+++ b/src/RightContent/AvatarDropdown.tsx
@@ -1,13 +1,12 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { LogoutOutlined, SettingOutlined } from '@ant-design/icons';
 import { Avatar, Menu, Spin } from 'antd';
 import HeaderDropdown from './HeaderDropdown';
 import { UserOutlined } from '@ant-design/icons';
 import styles from './index.less';
-import type { MenuInfo } from 'rc-menu/lib/interface';
 import { getSsoUrl } from '../utils/utils';
 
-import type { FormatMessageProp, UserlogoutProps } from './index.types';
+import type { FormatMessageProp, UserlogoutProps, DropdownProps } from './index.types';
 
 export type GlobalHeaderRightProps = {
   onUserlogout: UserlogoutProps;
@@ -15,6 +14,7 @@ export type GlobalHeaderRightProps = {
   currentUser: {
     name: string;
   };
+  extendsAvatarDropdown?: DropdownProps[];
 };
 
 /**
@@ -25,25 +25,19 @@ const loginOut: (onUserlogout: UserlogoutProps) => Promise<void> = async (onUser
   window.location.assign(`${getSsoUrl()}/login`);
 };
 
-const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ onUserlogout, formatMessage, currentUser }) => {
-  const onMenuClick = useCallback(
-    (event: MenuInfo) => {
-      const { key } = event;
-      if (key === 'logout' && currentUser) {
-        loginOut(onUserlogout);
-      }
-      if(key === 'setting') window.location.assign(`${getSsoUrl()}/profile`);
-    },
-    [currentUser, onUserlogout]
-  );
-
+const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({
+  onUserlogout,
+  formatMessage,
+  currentUser,
+  extendsAvatarDropdown = [],
+}) => {
   const loading = (
     <span className={`${styles.action} ${styles.account}`}>
       <Spin
-        size='small'
+        size="small"
         style={{
           marginLeft: 8,
-          marginRight: 8
+          marginRight: 8,
         }}
       />
     </span>
@@ -58,26 +52,35 @@ const AvatarDropdown: React.FC<GlobalHeaderRightProps> = ({ onUserlogout, format
   }
 
   const menuHeaderDropdown = (
-    <Menu className={styles.menu} onClick={onMenuClick}>
-      <Menu.Item key='setting'>
+    <Menu className={styles.menu}>
+      <Menu.Item key="setting" onClick={() => window.location.assign(`${getSsoUrl()}/profile`)}>
         <SettingOutlined />
         {formatMessage({
-          id: 'common.nav.settings'
+          id: 'common.nav.settings',
         })}
       </Menu.Item>
-      <Menu.Item key='logout'>
+      <Menu.Item key="logout" onClick={() => loginOut(onUserlogout)}>
         <LogoutOutlined />
         {formatMessage({
-          id: 'common.nav.logout'
+          id: 'common.nav.logout',
         })}
       </Menu.Item>
+      {extendsAvatarDropdown.length > 0 &&
+        extendsAvatarDropdown.map(({ Icon, label, onClick }) => {
+          return (
+            <Menu.Item key="logout" onClick={onClick}>
+              {Icon || <span style={{ paddingLeft: '22px' }}> </span>}
+              {label}
+            </Menu.Item>
+          );
+        })}
     </Menu>
   );
 
   return (
     <HeaderDropdown overlay={menuHeaderDropdown}>
       <span className={`${styles.action} ${styles.account}`}>
-        <Avatar className={styles.avatar} icon={<UserOutlined />} alt='avatar' />
+        <Avatar className={styles.avatar} icon={<UserOutlined />} alt="avatar" />
         {currentUser.name}
       </span>
     </HeaderDropdown>

--- a/src/RightContent/ExplorationDropdown.tsx
+++ b/src/RightContent/ExplorationDropdown.tsx
@@ -17,6 +17,7 @@ const ServiceMenu: React.FC<{
       url: service.externalDomain,
       onClick: service.onClick,
       serviceName: service.serviceName,
+      Icon: service.Icon,
     };
   });
   return (
@@ -43,6 +44,7 @@ const ServiceMenu: React.FC<{
               }
             }}
           >
+            {app.Icon}
             {app.name}
           </Menu.Item>
         );

--- a/src/RightContent/HeaderRight.tsx
+++ b/src/RightContent/HeaderRight.tsx
@@ -5,7 +5,7 @@ import Avatar from './AvatarDropdown';
 import ExplorationDropdown from './ExplorationDropdown';
 import InfoDropdown from './InfoDropdown';
 
-import type { ServiceProp, FormatMessageProp, UserlogoutProps } from './index.types';
+import type { ServiceProp, FormatMessageProp, UserlogoutProps, DropdownProps } from './index.types';
 
 export type SiderTheme = 'light' | 'dark';
 
@@ -25,6 +25,8 @@ export interface HeaderRightProps {
   onTracking: (type: string) => void;
   services: ServiceProp[];
   onUpdateLocale: (lang: string, realReload?: boolean) => void;
+  extendsAvatarDropdown?: DropdownProps[];
+  extendsInfoDropdown?: DropdownProps[];
 }
 
 export const HeaderRight: React.FC<HeaderRightProps> = ({
@@ -36,6 +38,8 @@ export const HeaderRight: React.FC<HeaderRightProps> = ({
   currentUser,
   onTracking,
   services,
+  extendsAvatarDropdown,
+  extendsInfoDropdown,
 }) => {
   let className = styles.right;
 
@@ -44,13 +48,22 @@ export const HeaderRight: React.FC<HeaderRightProps> = ({
   }
   return (
     <Space className={className} size={32}>
-      <InfoDropdown formatMessage={formatMessage} onTracking={onTracking} />
+      <InfoDropdown
+        formatMessage={formatMessage}
+        onTracking={onTracking}
+        extendsInfoDropdown={extendsInfoDropdown}
+      />
       <ExplorationDropdown
         formatMessage={formatMessage}
         services={services}
         onTracking={onTracking}
       />
-      <Avatar onUserlogout={onUserlogout} formatMessage={formatMessage} currentUser={currentUser} />
+      <Avatar
+        onUserlogout={onUserlogout}
+        formatMessage={formatMessage}
+        currentUser={currentUser}
+        extendsAvatarDropdown={extendsAvatarDropdown}
+      />
       {versionTag && (
         <span>
           <Tag color={ENVTagColor[versionTag]}>{versionTag}</Tag>

--- a/src/RightContent/InfoDropdown.tsx
+++ b/src/RightContent/InfoDropdown.tsx
@@ -3,12 +3,13 @@ import { Menu } from 'antd';
 import styles from './index.less';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import HeaderDropdown from './HeaderDropdown';
-import type { FormatMessageProp } from './index.types';
+import type { FormatMessageProp, DropdownProps } from './index.types';
 
-const QuestionMenu: React.FC<{ onTracking: (type: string) => void; formatMessage: FormatMessageProp }> = ({
-  formatMessage,
-  onTracking
-}) => {
+const QuestionMenu: React.FC<{
+  onTracking: (type: string) => void;
+  formatMessage: FormatMessageProp;
+  extendsInfoDropdown?: DropdownProps[];
+}> = ({ formatMessage, onTracking, extendsInfoDropdown = [] }) => {
   return (
     <Menu>
       <Menu.Item
@@ -27,18 +28,34 @@ const QuestionMenu: React.FC<{ onTracking: (type: string) => void; formatMessage
       >
         {formatMessage({ id: 'common.nav.faq' })}
       </Menu.Item>
+      {extendsInfoDropdown.length > 0 &&
+        extendsInfoDropdown.map(({ Icon, label, onClick }) => {
+          return (
+            <Menu.Item key="logout" onClick={onClick}>
+              {Icon}
+              {label}
+            </Menu.Item>
+          );
+        })}
     </Menu>
   );
 };
 
-const InfoDropDwon: React.FC<{ onTracking: (type: string) => void; formatMessage: FormatMessageProp }> = ({
-  formatMessage,
-  onTracking
-}) => {
+const InfoDropDwon: React.FC<{
+  onTracking: (type: string) => void;
+  formatMessage: FormatMessageProp;
+  extendsInfoDropdown?: DropdownProps[];
+}> = ({ formatMessage, onTracking, extendsInfoDropdown }) => {
   return (
     <HeaderDropdown
-      overlay={<QuestionMenu formatMessage={formatMessage} onTracking={onTracking} />}
-      placement='bottomRight'
+      overlay={
+        <QuestionMenu
+          formatMessage={formatMessage}
+          onTracking={onTracking}
+          extendsInfoDropdown={extendsInfoDropdown}
+        />
+      }
+      placement="bottomRight"
     >
       <span className={styles.action}>
         <QuestionCircleOutlined />

--- a/src/RightContent/index.types.ts
+++ b/src/RightContent/index.types.ts
@@ -2,6 +2,7 @@ export interface ServiceProp {
   externalDomain: string;
   serviceName: string;
   onClick?: () => void;
+  Icon?: HTMLElement;
 }
 export interface FormatMessageProp {
   ({ id }: { id: string }): string;
@@ -10,3 +11,9 @@ export interface FormatMessageProp {
 export interface UserlogoutProps {
   (): Promise<void>;
 }
+
+export type DropdownProps = {
+  label: string;
+  onClick: () => void;
+  Icon?: HTMLElement;
+};

--- a/src/RightContent/stories/Header.stories.tsx
+++ b/src/RightContent/stories/Header.stories.tsx
@@ -38,5 +38,17 @@ Primary.args = {
     },
   ],
   formatMessage: ({ id }) => id,
-  onTracking: () => {}
+  extendsAvatarDropdown: [
+    {
+      label: 'extendsAvatarDropdown',
+      onClick: () => {},
+    },
+  ],
+  extendsInfoDropdown: [
+    {
+      label: 'extendsInfoDropdown',
+      onClick: () => {},
+    },
+  ],
+  onTracking: () => {},
 };


### PR DESCRIPTION
Description:
Add extend props for info and avatar dropdown.

```
  extendsAvatarDropdown,
  extendsInfoDropdown,
```

There is a type schema.
```
export type DropdownProps = {
  label: string;
  onClick: () => void;
  Icon: HTMLElement;
};
```

CheckList:
- [x] You have pass unit test. 
- [] You have added unit tests.
- [x] You have edit storybook document. If you add or update component.